### PR TITLE
Fix openedx_backup resource configuration

### DIFF
--- a/{{cookiecutter.github_repo_name}}/terraform/environments/modules/s3_openedx_storage/main.tf
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/modules/s3_openedx_storage/main.tf
@@ -32,6 +32,9 @@ module "openedx_backup" {
   bucket = var.resource_name_backup
   acl    = "private"
 
+  versioning = {
+    enabled = true
+  }
 }
 
 module "openedx_secrets" {
@@ -57,7 +60,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       type        = "*"
     }
     resources = [
-      "${module.openedx_storage.s3_bucket_arn}/*"
+      "${module.openedx_storage.s3_bucket_arn}/*",
     ]
   }
 }
@@ -78,7 +81,8 @@ data "aws_iam_policy_document" "user_policy" {
       "s3:*"
     ]
     resources = [
-      module.openedx_storage.s3_bucket_arn
+      module.openedx_storage.s3_bucket_arn,
+      module.openedx_backup.s3_bucket_arn
     ]
   }
   statement {
@@ -86,7 +90,8 @@ data "aws_iam_policy_document" "user_policy" {
       "s3:*"
     ]
     resources = [
-      "${module.openedx_storage.s3_bucket_arn}/*"
+      "${module.openedx_storage.s3_bucket_arn}/*",
+      "${module.openedx_backup.s3_bucket_arn}/*"
     ]
   }
 }

--- a/{{cookiecutter.github_repo_name}}/terraform/environments/modules/s3_openedx_storage/main.tf
+++ b/{{cookiecutter.github_repo_name}}/terraform/environments/modules/s3_openedx_storage/main.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "bucket_policy" {
       type        = "*"
     }
     resources = [
-      "${module.openedx_storage.s3_bucket_arn}/*",
+      "${module.openedx_storage.s3_bucket_arn}/*"
     ]
   }
 }


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [X] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes #[Add issue number here.]

I'm unsure if this was a known bug. But our terraform installation did not make s3 buckets versioned by default. When versioning is disabled, backup verification will fail.

Also, the generated s3 user was unable to upload backups generated by the openedx backup container to s3.

### Describe Changes
<!-- Describe your changes in detail, if applicable. -->
- Explicitly enable versioning on the `openedx_backup` bucket
- Allow the `user_policy` to access the `openedx_backup` bucket and objects
